### PR TITLE
Allow include surround blank lines into each fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ Plug 'lvht/phpfold.vim', { 'for': 'php' }
 
 # usage
 Use <kbd>zm</kbd> or <kbd>:PhpFold<CR></kbd> to fold the php file.
+
+Set
+```
+let g:phpfold_include_surround_blank_lines = 'downward'
+```
+if you want to include surround blank lines into each fold. You can set it also to `upward`.

--- a/autoload/phpfold.vim
+++ b/autoload/phpfold.vim
@@ -1,13 +1,38 @@
 function! phpfold#Fold(points) " {{{
+	let step = <SID>getStepOutsideFold()
 	for point in a:points
-		let lineStart = point[0]
-		let lineStop = point[1]
+		let lineStart = <SID>getFarestSurroundingBlankLine(point[0], step)
+		let lineStop = <SID>getFarestSurroundingBlankLine(point[1], step)
 		if foldlevel(lineStart) != 0
 			continue
 		endif
 		exec lineStart.','.lineStop.'fold'
 	endfor
 endfunction " }}}
+
+function! s:getStepOutsideFold() "{{{
+	if exists('g:phpfold_include_surround_blank_lines')
+		return 'upward' is g:phpfold_include_surround_blank_lines ? -1 : 1
+	endif
+
+	return 0
+endfunction	}}}"
+
+function! s:getFarestSurroundingBlankLine(lineNumber, step)
+		if 0 is a:step
+			return a:lineNumber
+		endif
+
+    let step = a:step > 0 ? 1 : -1
+    let extremalLineNumber = (step >= 0) ? line('$') : 1
+    let currentLine = a:lineNumber
+
+    while currentLine != extremalLineNumber && getline(currentLine + step) =~? '\v^\s*$'
+        let currentLine += step
+    endwhile
+
+    return currentLine
+endfunction
 
 function! phpfold#PHPFoldText() " {{{
 	let currentLine = v:foldstart

--- a/ftplugin/php_phpfold.vim
+++ b/ftplugin/php_phpfold.vim
@@ -10,7 +10,7 @@ set cpo&vim
 setlocal foldmethod=manual
 setlocal foldtext=phpfold#PHPFoldText()
 
-function! s:doFold(status, response)
+function! s:doFold(status, response, ...)
 	let points = json_decode(a:response)
 	call phpfold#Fold(points)
 	normal! zv


### PR DESCRIPTION
It also fixes error with wrong doFold's argument number in neovim.