### PR TITLE
Fix phpfold error in neovim

### DIFF
--- a/ftplugin/php_phpfold.vim
+++ b/ftplugin/php_phpfold.vim
@@ -11,6 +11,9 @@ setlocal foldmethod=manual
 setlocal foldtext=phpfold#PHPFoldText()
 
 function! s:doFold(status, response, ...)
+	if len(a:response) == 1 && a:response[0] == ''
+		return
+	endif
 	let points = json_decode(a:response)
 	call phpfold#Fold(points)
 	normal! zv


### PR DESCRIPTION
close https://github.com/SpaceVim/SpaceVim/issues/1568

@lvht 在版本的 neovim， 回调函数传过来的数据结尾会多一个 `['']`, 在做 json_decode 时需要将这个例外情况排除掉。